### PR TITLE
State Machine Unit Tests

### DIFF
--- a/SessionState.js
+++ b/SessionState.js
@@ -1,5 +1,3 @@
-const db = require("./db/db.js");
-
 const STATE = {
     RESET: 'Reset',
     NO_PRESENCE_NO_SESSION: 'No Presence, No active session',
@@ -35,7 +33,7 @@ class SessionState {
         this.location = location;
     }
 
-    async getNextState() {
+    async getNextState(db) {
 
         let state;
 
@@ -198,23 +196,6 @@ class SessionState {
         }
         return state;
     }
-
-    /*
-    async checkDoorSession() {
-        
-        let door = await db.getLatestDoorSensordata(this.location);
-        let session = await db.getMostRecentSession(this.location);
-
-        if(session != undefined) {
-            if(door.signal == "open") {
-                return STATE.DOOR_OPENED_CLOSE;
-            }
-        }
-        else {
-            return null;
-        }
-    }
-    */
 }
 
 module.exports = SessionState;

--- a/SessionState.js
+++ b/SessionState.js
@@ -1,31 +1,5 @@
-const STATE = {
-    RESET: 'Reset',
-    NO_PRESENCE_NO_SESSION: 'No Presence, No active session',
-    NO_PRESENCE_CLOSE: "No Presence, Closing active session",
-    DOOR_OPENED_START: "Door Opened: Start Session",
-    DOOR_CLOSED_START: "Door Closed: Start Session",
-    DOOR_OPENED_CLOSE: "Door Opened: Closing active session",
-    MOTION_DETECTED: "Motion has been detected",
-    MOVEMENT: 'Movement',
-    STILL: 'Still',
-    BREATH_TRACKING: 'Breathing',
-    SUSPECTED_OD: 'Suspected Overdose',
-    STARTED: 'Started',
-    WAITING_FOR_RESPONSE: 'Waiting for Response',
-    WAITING_FOR_CATEGORY: 'Waiting for Category',
-    WAITING_FOR_DETAILS: 'Waiting for Details',
-    COMPLETED: 'Completed'
-};
-
-const XETHRU_STATES = {
-    BREATHING: "0",
-    MOVEMENT: "1",
-    MOVEMENT_TRACKING: "2",
-    NO_MOVEMENT: "3",
-    INITIALIZING: "4",
-    ERROR: "5",
-    UNKNOWN: "6"
-};
+const STATE = require('./SessionStateEnum.js');
+const XETHRU_STATE = require('./SessionStateXethruEnum.js');
 
 class SessionState {
 
@@ -69,7 +43,7 @@ class SessionState {
                             state = STATE.DOOR_OPENED_START;
                         }
                             // Waits for both the XeThru and motion sensor to be active
-                        else if (xethru.mov_f > residual_mov_f && xethru.state != XETHRU_STATES.NO_MOVEMENT && motion.signal == "active") {
+                        else if (xethru.mov_f > residual_mov_f && xethru.state != XETHRU_STATE.NO_MOVEMENT && motion.signal == "active") {
                             state = STATE.MOTION_DETECTED;
                         }
                         break;
@@ -84,7 +58,7 @@ class SessionState {
                     }
                 case STATE.DOOR_CLOSED_START:
                     {
-                        if (xethru.state != XETHRU_STATES.NO_MOVEMENT || motion.signal == "active") {
+                        if (xethru.state != XETHRU_STATE.NO_MOVEMENT || motion.signal == "active") {
                             state = STATE.MOVEMENT;
                         }
                         break;
@@ -109,17 +83,17 @@ class SessionState {
                         let session = await db.getMostRecentSession(this.location);
 
                         //if state is no movement, chenge to STATE_NO_PRESENCE
-                        if (xethru.state == XETHRU_STATES.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
+                        if (xethru.state == XETHRU_STATE.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
                             state = STATE.NO_PRESENCE_CLOSE;
                         }
                         else if (door.signal == "open" && !session.od_flag) {
                             state = STATE.DOOR_OPENED_CLOSE;
                         }
                             //if in breathing state, change to that state
-                        else if (xethru.state == XETHRU_STATES.BREATHING) {
+                        else if (xethru.state == XETHRU_STATE.BREATHING) {
                             state = STATE.BREATH_TRACKING;
                         }
-                        else if (xethru.mov_f == 0 && xethru.state != XETHRU_STATES.NO_MOVEMENT) { 
+                        else if (xethru.mov_f == 0 && xethru.state != XETHRU_STATE.NO_MOVEMENT) { 
                             state = STATE.STILL;
                         }
                         
@@ -135,13 +109,13 @@ class SessionState {
                     {
                         let session = await db.getMostRecentSession(this.location);
 
-                        if (xethru.state == XETHRU_STATES.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
+                        if (xethru.state == XETHRU_STATE.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
                             state = STATE.NO_PRESENCE_CLOSE;
                         }
                         else if (door.signal == "open" && !session.od_flag) {
                             state = STATE.DOOR_OPENED_CLOSE;
                         }
-                        else if (xethru.state == XETHRU_STATES.BREATHING) {
+                        else if (xethru.state == XETHRU_STATE.BREATHING) {
                             state = STATE.BREATH_TRACKING;
                         }
                         else if (xethru.mov_f > 0) {
@@ -159,17 +133,17 @@ class SessionState {
                         let session = await db.getMostRecentSession(this.location);
 
 
-                        if (xethru.state == XETHRU_STATES.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
+                        if (xethru.state == XETHRU_STATE.NO_MOVEMENT && motion.signal == "inactive" && !session.od_flag) {
                             state = STATE.NO_PRESENCE_CLOSE;
                         }
                         else if (door.signal == "open" && !session.od_flag) {
                             state = STATE.DOOR_OPENED_CLOSE;
                         }
-                        else if(xethru.state != XETHRU_STATES.BREATHING && xethru.mov_f == 0) {
+                        else if(xethru.state != XETHRU_STATE.BREATHING && xethru.mov_f == 0) {
                             state = STATE.STILL;
                         }
                             //returns to movement if not in breathing state
-                        else if (xethru.state != XETHRU_STATES.BREATHING) {
+                        else if (xethru.state != XETHRU_STATE.BREATHING) {
                             state = STATE.MOVEMENT;
                         }
 

--- a/SessionStateEnum.js
+++ b/SessionStateEnum.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const STATE = {
+    RESET: 'Reset',
+    NO_PRESENCE_NO_SESSION: 'No Presence, No active session',
+    NO_PRESENCE_CLOSE: "No Presence, Closing active session",
+    DOOR_OPENED_START: "Door Opened: Start Session",
+    DOOR_CLOSED_START: "Door Closed: Start Session",
+    DOOR_OPENED_CLOSE: "Door Opened: Closing active session",
+    MOTION_DETECTED: "Motion has been detected",
+    MOVEMENT: 'Movement',
+    STILL: 'Still',
+    BREATH_TRACKING: 'Breathing',
+    SUSPECTED_OD: 'Suspected Overdose',
+    STARTED: 'Started',
+    WAITING_FOR_RESPONSE: 'Waiting for Response',
+    WAITING_FOR_CATEGORY: 'Waiting for Category',
+    WAITING_FOR_DETAILS: 'Waiting for Details',
+    COMPLETED: 'Completed'
+};
+
+module.exports = Object.freeze(STATE);

--- a/SessionStateXethruEnum.js
+++ b/SessionStateXethruEnum.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const XETHRU_STATE = {
+    BREATHING: "0",
+    MOVEMENT: "1",
+    MOVEMENT_TRACKING: "2",
+    NO_MOVEMENT: "3",
+    INITIALIZING: "4",
+    ERROR: "5",
+    UNKNOWN: "6"
+};
+
+module.exports = Object.freeze(XETHRU_STATE);

--- a/index.js
+++ b/index.js
@@ -297,7 +297,7 @@ app.post('/sms', async function (req, res) {
 setInterval(async function () {
   for(let i = 0; i < locations.length; i++){
     let statemachine = new SessionState(locations[i]);
-    let currentState = await statemachine.getNextState();
+    let currentState = await statemachine.getNextState(db);
     let prevState = await db.getLatestLocationStatesdata(locations[i]);
     
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,0 @@
-let chai = require('chai');
-const expect = chai.expect;
-
-describe('test test', () => {
-	it('should always pass', () => {
-		expect(true).to.true;
-	});
-});

--- a/test/testSessionState.js
+++ b/test/testSessionState.js
@@ -2,35 +2,85 @@ let chai = require('chai');
 const expect = chai.expect;
 const STATE = require('./../SessionStateEnum.js');
 const XETHRU_STATE = require('./../SessionStateXethruEnum.js');
-
 const SessionState = require('./../SessionState.js');
 
-describe('test getNextState', () => {
-	it('when no initial state should return the RESET state', async () => {
-		let db = {
-			getLocationData: function(location) {
-				// initial state
-				return {};
-			},
-			getLatestXeThruSensordata: function(location) {
-				return {};
-			},
-			getLatestDoorSensordata: function(location) {
-				return {};
-			},
-			getLatestMotionSensordata: function(location) {
-				return {};
-			},
-			getLatestLocationStatesdata: function(location) {
-				return {};
-			},
-			addStateMachineData: function(state, location) {
-			}
+function setupDB(states = {}, door = {}, motion = {}, xethru = {}, location_data = {}) {
+	return {
+		getLatestLocationStatesdata: function(location) {
+			// initial state
+			return states;
+		},
+		getLatestXeThruSensordata: function(location) {
+			return xethru;
+		},
+		getLatestDoorSensordata: function(location) {
+			return door;
+		},
+		getLatestMotionSensordata: function(location) {
+			return motion;
+		},
+		getLocationData: function(location) {
+			return location_data;
+		},
+		addStateMachineData: function(state, location) {
 		}
-		let statemachine = new SessionState('TestLocation');
+	}
+}
 
-		let actualState = await statemachine.getNextState(db);
+describe('test getNextState', () => {
+	describe('when no inital state', () => {
+		it('should return the RESET state', async () => {
+			let db = setupDB();
+			let statemachine = new SessionState('TestLocation');
 
-		expect(actualState).to.equal(STATE.RESET);
+			let actualState = await statemachine.getNextState(db);
+
+			expect(actualState).to.equal(STATE.RESET);
+		});
+	});
+
+	describe('when inital state is NO_PRESENCE_NO_SESSION', () => {
+		it('and the door opens, should return the DOOR_OPENED_START state', async () => {
+			let db = setupDB(
+				states = {state: STATE.NO_PRESENCE_NO_SESSION},
+				door = {signal:"open"}
+			);
+			let statemachine = new SessionState('TestLocation');
+
+			let actualState = await statemachine.getNextState(db);
+
+			expect(actualState).to.equal(STATE.DOOR_OPENED_START);
+		});
+
+		it('and the door closes, should not change state', async () => {
+			let initialState = STATE.NO_PRESENCE_NO_SESSION;
+			let db = setupDB(
+				states = {state: initialState},
+				door = {signal: "closed"}
+			);
+			let statemachine = new SessionState('TestLocation');
+
+			let actualState = await statemachine.getNextState(db);
+
+			expect(actualState).to.equal(initialState);
+		});
+
+		it(', the motion sensor is active, the xethru detects movement, and the xethru movement is more than the movement threshold, should return the MOTION_DETECTED state', async () => {
+			let db = setupDB(
+				states = {state: STATE.NO_PRESENCE_NO_SESSION},
+				door = {},
+				motion = {signal: "active"},
+				xethru = {
+					state: XETHRU_STATE.MOVEMENT,
+					mov_f: 6
+				},
+				location_data = {mov_threshold: 5}
+			);
+			let statemachine = new SessionState('TestLocation');
+
+			let actualState = await statemachine.getNextState(db);
+
+			expect(actualState).to.equal(STATE.MOTION_DETECTED);
+		});
 	});
 });

--- a/test/testSessionState.js
+++ b/test/testSessionState.js
@@ -65,7 +65,7 @@ describe('test getNextState', () => {
 			expect(actualState).to.equal(initialState);
 		});
 
-		it(', the motion sensor is active, the xethru detects movement, and the xethru movement is more than the movement threshold, should return the MOTION_DETECTED state', async () => {
+		it('and the motion sensor is active and the xethru detects movement and the xethru movement is more than the movement threshold, should return the MOTION_DETECTED state', async () => {
 			let db = setupDB(
 				states = {state: STATE.NO_PRESENCE_NO_SESSION},
 				door = {},

--- a/test/testSessionState.js
+++ b/test/testSessionState.js
@@ -1,0 +1,36 @@
+let chai = require('chai');
+const expect = chai.expect;
+const STATE = require('./../SessionStateEnum.js');
+const XETHRU_STATE = require('./../SessionStateXethruEnum.js');
+
+const SessionState = require('./../SessionState.js');
+
+describe('test getNextState', () => {
+	it('when no initial state should return the RESET state', async () => {
+		let db = {
+			getLocationData: function(location) {
+				// initial state
+				return {};
+			},
+			getLatestXeThruSensordata: function(location) {
+				return {};
+			},
+			getLatestDoorSensordata: function(location) {
+				return {};
+			},
+			getLatestMotionSensordata: function(location) {
+				return {};
+			},
+			getLatestLocationStatesdata: function(location) {
+				return {};
+			},
+			addStateMachineData: function(state, location) {
+			}
+		}
+		let statemachine = new SessionState('TestLocation');
+
+		let actualState = await statemachine.getNextState(db);
+
+		expect(actualState).to.equal(STATE.RESET);
+	});
+});


### PR DESCRIPTION
Hi Mario,

Here is the start of a set of unit tests for the state machine. To add more tests, add them to tests/testSessionState.js. Hopefully it's clear what is happening in each one. It basically sets the initial state to whatever you tell it to, then you provide the responses to the DB calls that will determine what happened. Then it calls `statemachine.getNextState` and checks the value that it returns against what we expected.

To run the tests locally, just call `npm test`.
To run them on Jenkins, just push your changes.

Other things that I changed to make these unit tests work:
* Factored out the STATE and XETHRUSTATES enums so that I could use them in both the prod code and the test code
* Renamed XETHRUSTATES to XETHRUSTATE to be consistent with the singular STATE constant
* Made `db` a parameter into `getNextState` instead of a constant in `SessionState.js`. This is what allowed me to substitute the fake DB setup in the tests. So now in the prod code, it needs to supply the `db` parameter when it calls `getNextState`
* Removed that commented out code because I don't like leaving in commented-out code

The tests themselves are working fine, but I haven't checked that the full application still works after these changes. So would you mind checking that that part works for you when you run this on your local and then it can merged in to master whenever you feel like it.

Thanks!