### PR TITLE
[DO NOT MERGE] Call a console.log from brave-alert-lib (CU-baqucz) 

### DIFF
--- a/SessionState.js
+++ b/SessionState.js
@@ -5,10 +5,15 @@ const DOOR_STATE = require('./SessionStateDoorEnum.js');
 const Sentry = require('@sentry/node');
 Sentry.init({ dsn: 'https://a95c3fc9c5fd49b29dbe5672228184a0@sentry.io/2556408' });
 let moment = require('moment');
+const BraveAlerter = require('brave-alert-lib');
+
 class SessionState {
 
     constructor(location) {
         this.location = location;
+
+        var braveAlerter = new BraveAlerter();
+        braveAlerter.output();
     }
 
     async getNextState(db, redis) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,6 +405,10 @@
         "concat-map": "0.0.1"
       }
     },
+    "brave-alert-lib": {
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#b4c15d44e6ac2c83cdb1a83088e1115fb1a61e22",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v0.1.0"
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@smartthings/smartapp": "^1.0.3",
     "axios": "^0.19.2",
     "body-parser": "*",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v0.1.0",
     "chai": "^4.2.0",
     "chai-http": "^4.2.0",
     "cookie-parser": "^1.4.4",


### PR DESCRIPTION
# DO NOT MERGE

- Just to prove that the brave-alert-lib can be included as a dependency of ODetect-Backend-Local using the `v0.1.0` tag and can be called from its code
    - You can see the console.log happening in the [test output in Travis](https://travis-ci.com/github/bravetechnologycoop/ODetect-Backend-Local/builds/182156632): "BraveAlertLib here"