### PR TITLE
Minimal changes to distinguish between multiple bathrooms at a location (CU-cumnc0)

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -198,9 +198,9 @@ async function getSessionWithSessionId(sessionid){
 
 
 // Gets the last session data in the table for a specified phone number
-async function getMostRecentSessionPhone(phone){
+async function getMostRecentSessionPhone(twilioPhone){
   try {
-      const results = await pool.query("SELECT * FROM sessions WHERE phonenumber = $1  AND start_time > (CURRENT_TIMESTAMP - interval '7 days') ORDER BY start_time DESC LIMIT 1", [phone]);
+      const results = await pool.query("SELECT s.* FROM sessions AS s LEFT JOIN locations AS l ON s.locationid = l.locationid WHERE l.twilio_number = $1  AND s.start_time > (CURRENT_TIMESTAMP - interval '7 days') ORDER BY s.start_time DESC LIMIT 1", [twilioPhone]);
       if(results == undefined){
           return null;
       }

--- a/index.js
+++ b/index.js
@@ -593,10 +593,10 @@ async function sendBatteryAlert(location,signal) {
 app.post('/sms', async function (req, res) {
 const twiml = new MessagingResponse()
   // Parses out information from incoming message
-  var from = req.body.From;
+  var to = req.body.To;
   var body = req.body.Body;
 
-  let session = await db.getMostRecentSessionPhone(from);
+  let session = await db.getMostRecentSessionPhone(to);
   let chatbot = new Chatbot(session.sessionid, session.locationid, session.chatbot_state, session.phonenumber, session.incidenttype, session.notes);
   let message = chatbot.advanceChatbot(body);
   await db.saveChatbotSession(chatbot);


### PR DESCRIPTION
- The /sms endpoint is hit when the Responder phone replies to an alert.
  Using the `req.body.From` as the lookup phone number means that we're
  using the Responder phone number. This was fine when there was only
  a single bathroom per location because the Responder phone would line
  up with exactly one bathroom. However, now that we have some locations
  with multiple bathrooms, we need to the use the `req.body.To` number
  to disambiguate.
- Investigating this bug revealed a lot of test data in the `sessions`
  table that I didn't want to change. So instead of updating the
  `phonenumber` column in `sessions` (which may also be confusing since
  the term `phonenumer` in the `locations` table specifically refers to
  the Responder phone number), I instead just changed the query to join
  with `locations` and get the `twilio_number` for the given location
- This may make our performance worse, but since the `locations` table
  doesn't have many entries, I'd be surprised if it's a big difference
- It also means that we aren't really using the `phonenumber` column in the
`sessions` table anymore. But I don't want to remove it until we figure out 
whether we need that data for anything.