### PR TITLE
Fix fallback message sending

### DIFF
--- a/index.js
+++ b/index.js
@@ -511,8 +511,8 @@ async function fallbackMessage(sessionid) {
     console.log("Fallback if block");
     let locationData = await db.getLocationData(session.locationid)
     console.log(`fallback number is:  ${locationData.fallback_phonenumber}`)
-    console.log(`twilio number is:  ${locationData.twilio}`)
-    await sendTwilioMessage(locationData.twilio_number, locationData.fallback_number,`An alert to check on the washroom at ${locationData.location_human} was not responded to. Please check on it`)
+    console.log(`twilio number is:  ${locationData.twilio_number}`)
+    await sendTwilioMessage(locationData.twilio_number, locationData.fallback_phonenumber,`An alert to check on the washroom at ${locationData.location_human} was not responded to. Please check on it`)
   }
 //else do nothing
 } 


### PR DESCRIPTION
* Typo that means that no fallback messages are ever sent (because their toPhoneNumber value is always empty)
* Typo that means that the log message is incorrect